### PR TITLE
symmetric caps lock key pushes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,19 @@ take corresponding actions.
 it uses ``evdev``, ``udev`` and ``uinput`` and hence works with wayland and
 on the console.
 
+Usage
+==============
+
+.. code:: sh
+
+  sudo ./evcape.py
+
+Dependencies
+==============
+
+``evcape`` uses python's evdev and udev libaries.
+On debian, ``apt install python3-evdev python3-pyudev``
+
 current status
 ==============
 

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,8 @@ Usage
 
 .. code:: sh
 
+  # if remaping capslock as in DEFAULT_RULES
+  setxkbmap -option "caps:ctrl_modifier" 
   sudo ./evcape.py
 
 Dependencies
@@ -54,3 +56,4 @@ but is not limited to xorg.
 
 ``caps2esc`` (https://gitlab.com/interception/linux/plugins/caps2esc) and ``interception tools`` (https://gitlab.com/interception/linux/tools)
 
+``setxkbmap -option "caps:swapescape"``

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,17 @@ take corresponding actions.
 it uses ``evdev``, ``udev`` and ``uinput`` and hence works with wayland and
 on the console.
 
+Usage
+==============
+  .. code:: bash
+  sudo ./evcape.py
+
+Dependencies
+==============
+
+``evcape`` uses python's evdev and udev libaries.
+On debian, ``apt install python3-evdev python3-pyudev``
+
 current status
 ==============
 

--- a/README.rst
+++ b/README.rst
@@ -50,3 +50,7 @@ similar projects
 
 ``evcape`` is inspired by ``xcape`` (https://github.com/alols/xcape),
 but is not limited to xorg.
+
+
+``caps2esc`` (https://gitlab.com/interception/linux/plugins/caps2esc) and ``interception tools`` (https://gitlab.com/interception/linux/tools)
+

--- a/evcape.py
+++ b/evcape.py
@@ -45,10 +45,12 @@ def main():
     keyboard_monitor = KeyboardMonitor(
         ignored_devices=[uinput.device.fn])
 
+    # our buffer is as long as the longest sequence in rules
     window_size = max(
         [len(rule.patterns) for rule in rules])
     buffer = collections.deque(maxlen=window_size)
 
+    # put keypresses into a buffer and try to match rules
     with uinput, keyboard_monitor:
         for event in keyboard_monitor:
             lookup_key = (event.value, event.code)
@@ -65,6 +67,17 @@ def main():
                         evdev.ecodes.EV_KEY,
                         code,
                         value)
+
+                # if we matched capslock, we should toggle it again
+                # force symmetry in push/releases of capslock in pattern
+                for value, key in rule.patterns:
+                    if key != evdev.ecodes.KEY_CAPSLOCK:
+                        continue
+                    uinput.write(
+                            evdev.ecodes.EV_KEY,
+                            evdev.ecodes.KEY_CAPSLOCK,
+                            value)
+
                 uinput.syn()
 
 
@@ -188,6 +201,15 @@ class Rule(_Rule):
 
     @classmethod
     def from_string(cls, s):
+        """
+        create numeric rules from text
+          s='press:leftctrl,release:leftctrl=press:esc,release:esc',
+         becomes
+          Rule(patterns=[(1, 29), (0, 29)], actions=[(1, 1), (0, 1)])
+        where
+          KEY_LEFTCTRL = 29 ; KEY_ESC = 1
+          release = 0; press = 1
+        """
         patterns, _, actions = s.partition('=')
         return cls(
             patterns=cls.parse_sequence(patterns),

--- a/evcape.py
+++ b/evcape.py
@@ -67,17 +67,6 @@ def main():
                         evdev.ecodes.EV_KEY,
                         code,
                         value)
-
-                # if we matched capslock, we should toggle it again
-                # force symmetry in push/releases of capslock in pattern
-                for value, key in rule.patterns:
-                    if key != evdev.ecodes.KEY_CAPSLOCK:
-                        continue
-                    uinput.write(
-                            evdev.ecodes.EV_KEY,
-                            evdev.ecodes.KEY_CAPSLOCK,
-                            value)
-
                 uinput.syn()
 
 


### PR DESCRIPTION
hacky solution to #6 

with `DEFAULT_RULES`, caps lock is again toggled after esc is sent. The net effect is capslock is quickly set and unset.

But if e.g. <kbd>caps+A</kbd> is pushed, caps is still set and cannot be unset by caps alone (because it is symmetricly toggled every press). Any uncaught sequence with <kbd>capslock</kbd>, e.g. <bkd>caps+A</bkd> again, will unset capslock. Far from ideal. 